### PR TITLE
Recreate mask only if isSkeleton

### DIFF
--- a/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/SkeletonLayout.kt
+++ b/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/SkeletonLayout.kt
@@ -154,12 +154,15 @@ class SkeletonLayout @JvmOverloads constructor(
     private fun invalidateMask() {
         if (isRendered) {
             mask?.stop()
-            if (width > 0 && height > 0) {
-                mask = SkeletonMaskFactory
-                    .createMask(this, maskColor, showShimmer, shimmerColor, shimmerDurationInMillis)
-                    .also { mask -> mask.mask(this, maskCornerRadius) }
-            } else {
-                Log.e(tag(), "Failed to mask view with invalid width and height")
+            mask = null
+            if(isSkeleton) {
+                if (width > 0 && height > 0) {
+                    mask = SkeletonMaskFactory
+                        .createMask(this, maskColor, showShimmer, shimmerColor, shimmerDurationInMillis)
+                        .also { mask -> mask.mask(this, maskCornerRadius) }
+                } else {
+                    Log.e(tag(), "Failed to mask view with invalid width and height")
+                }
             }
         } else {
             Log.e(tag(), "Skipping invalidation until view is rendered")


### PR DESCRIPTION
I'm using the skeleton within a recyclerview and with using viewbinding. Obviously the viewbinding happens before onAttachedToWindow. So my viewbinding calls showOriginal, but afterwards onAttach gets called and recreates the mask, although it should not.