### PR TITLE
Add view limit level parameter when show skeleton

### DIFF
--- a/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/SkeletonLayout.kt
+++ b/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/SkeletonLayout.kt
@@ -11,21 +11,22 @@ import com.faltenreich.skeletonlayout.mask.SkeletonMaskFactory
 import com.faltenreich.skeletonlayout.mask.SkeletonShimmerDirection
 
 open class SkeletonLayout @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0,
-    originView: View? = null,
-    private val config: SkeletonConfig = SkeletonConfig.default(context)
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+        originView: View? = null,
+        private val config: SkeletonConfig = SkeletonConfig.default(context)
 ) : FrameLayout(context, attrs, defStyleAttr), Skeleton, SkeletonStyle by config {
 
     internal constructor(
-        originView: View,
-        config: SkeletonConfig
+            originView: View,
+            config: SkeletonConfig
     ) : this(originView.context, null, 0, originView, config)
 
     private var mask: SkeletonMask? = null
     private var isSkeleton: Boolean = false
     private var isRendered: Boolean = false
+    private var limitToLevel: Int = Int.MAX_VALUE
 
     init {
         attrs?.let {
@@ -68,7 +69,6 @@ open class SkeletonLayout @JvmOverloads constructor(
             }
         }
     }
-
     override fun isSkeleton(): Boolean = isSkeleton
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
@@ -117,8 +117,8 @@ open class SkeletonLayout @JvmOverloads constructor(
             if (isSkeleton) {
                 if (width > 0 && height > 0) {
                     mask = SkeletonMaskFactory
-                        .createMask(this, config)
-                        .also { mask -> mask.mask(this, maskCornerRadius) }
+                            .createMask(this, config)
+                            .also { mask -> mask.mask(this, maskCornerRadius,limitToLevel) }
                 } else {
                     Log.e(tag(), "Failed to mask view with invalid width and height")
                 }

--- a/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/mask/SkeletonMask.kt
+++ b/skeletonlayout/src/main/kotlin/com/faltenreich/skeletonlayout/mask/SkeletonMask.kt
@@ -40,17 +40,25 @@ internal abstract class SkeletonMask(protected val parent: View, @ColorInt color
         canvas.drawRect(rect, paint)
     }
 
-    fun mask(viewGroup: ViewGroup, maskCornerRadius: Float) {
+    fun mask(viewGroup: ViewGroup, maskCornerRadius: Float, offsetFromRootView:Int) {
         val xferPaint = Paint().apply {
             xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
             isAntiAlias = maskCornerRadius > 0
         }
-        mask(viewGroup, viewGroup, xferPaint, maskCornerRadius)
+        mask(viewGroup, viewGroup, xferPaint, maskCornerRadius,offsetFromRootView,currentLevel=0)
     }
 
-    private fun mask(view: View, root: ViewGroup, paint: Paint, maskCornerRadius: Float) {
+    private fun mask(view: View, root: ViewGroup, paint: Paint, maskCornerRadius: Float, limitViewLevel: Int, currentLevel:Int = 0) {
         (view as? ViewGroup)?.let { viewGroup ->
-            viewGroup.views().forEach { view -> mask(view, root, paint, maskCornerRadius) }
+            viewGroup.views().forEach {
+                if (limitViewLevel <= currentLevel){
+                    maskView(it, root, paint, maskCornerRadius)
+                }
+                else{
+                    mask(it, root, paint, maskCornerRadius,limitViewLevel,currentLevel+1)
+                }
+
+            }
         } ?: maskView(view, root, paint, maskCornerRadius)
     }
 


### PR DESCRIPTION
I see that showing skeleton for all leaf views (views at the bottom of the view tree and having no children) is not always give a good look. I have added an field named `limitToLevel: Int` (default = MAX_INT) to limit the depth at which the children in the SkeletonLayout should show skeleton and stop traveling down to their child views to show skeleton. This change does not requirement coders to modify their code except when they need to use the parameter. I hope you guys will consider my tiny effort. Thank you!